### PR TITLE
add feed page integration

### DIFF
--- a/graphql/generated/index.tsx
+++ b/graphql/generated/index.tsx
@@ -265,6 +265,7 @@ export type Query = {
   getAllTests: PaginatedResponseOfTestType;
   getAllTopics: PaginatedResponseOfTopicType;
   getAllUsers: PaginatedResponseOfUserType;
+  getFeed: PaginatedResponseOfNoticeType;
   getFileURL: Array<Scalars['String']>;
   getNotSubscribedTopics: Array<TopicType>;
   getNoticesByTopic: Array<Maybe<NoticeType>>;
@@ -323,6 +324,12 @@ export type QueryGetAllTopicsArgs = {
 export type QueryGetAllUsersArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   skip?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type QueryGetFeedArgs = {
+  limit?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']>;
 };
 
 
@@ -427,15 +434,15 @@ export type UserType = {
   __typename?: 'UserType';
   _id: Scalars['ID'];
   banned?: Maybe<Scalars['Boolean']>;
-  batch?: Maybe<Scalars['Int']>;
-  bio?: Maybe<Scalars['String']>;
+  batch: Scalars['Int'];
+  bio: Scalars['String'];
   discord: Scalars['String'];
   email: Scalars['String'];
   name: Scalars['String'];
   phone: Scalars['String'];
   posted?: Maybe<Array<NoticeType>>;
   preferences: PreferencesType;
-  profilePicture?: Maybe<Scalars['String']>;
+  profilePicture: Scalars['String'];
   role: Scalars['String'];
   subscribedEvents?: Maybe<Array<EventType>>;
   subscriptions?: Maybe<Array<TopicType>>;
@@ -443,7 +450,7 @@ export type UserType = {
 
 export type MinPostFragment = { __typename?: 'NoticeType', _id: string, time: string, title: string, body: string, topics?: Array<{ __typename?: 'TopicType', name: string, color: string }> | null };
 
-export type MinUserFragment = { __typename?: 'UserType', _id: string, name: string, batch?: number | null, email: string, profilePicture?: string | null, bio?: string | null };
+export type MinUserFragment = { __typename?: 'UserType', _id: string, name: string, batch: number, email: string, profilePicture: string, bio: string };
 
 export type UserPreferencesFragment = { __typename?: 'UserType', preferences: { __typename: 'PreferencesType', darkmode?: boolean | null, notifications?: boolean | null, roundup?: boolean | null } };
 
@@ -476,6 +483,14 @@ export type CreateFileUploadUrlQueryVariables = Exact<{
 
 export type CreateFileUploadUrlQuery = { __typename?: 'Query', url: Array<string> };
 
+export type GetFeedQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Float']>;
+  skip?: InputMaybe<Scalars['Float']>;
+}>;
+
+
+export type GetFeedQuery = { __typename?: 'Query', getFeed: { __typename?: 'PaginatedResponseOfNoticeType', data: Array<{ __typename?: 'NoticeType', _id: string, title: string, body: string, time: string, attachedImages?: Array<string> | null, isEvent: boolean, likeCount: number, postedBy: { __typename?: 'UserType', _id: string, name: string, profilePicture: string }, topics?: Array<{ __typename?: 'TopicType', _id: string, name: string, color: string }> | null, linkedEvents: Array<{ __typename?: 'EventType', _id: string, name: string, venue: string, date: string, meetLink: string }> }> } };
+
 export type GoogleAuthUrlQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -486,17 +501,17 @@ export type GoogleLoginQueryVariables = Exact<{
 }>;
 
 
-export type GoogleLoginQuery = { __typename?: 'Query', user: { __typename?: 'UserType', _id: string, name: string, batch?: number | null, email: string, profilePicture?: string | null, bio?: string | null } };
+export type GoogleLoginQuery = { __typename?: 'Query', user: { __typename?: 'UserType', _id: string, name: string, batch: number, email: string, profilePicture: string, bio: string } };
 
 export type LoggedInUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'UserType', _id: string, name: string, batch?: number | null, email: string, profilePicture?: string | null, bio?: string | null } | null };
+export type LoggedInUserQuery = { __typename?: 'Query', user?: { __typename?: 'UserType', _id: string, name: string, batch: number, email: string, profilePicture: string, bio: string } | null };
 
 export type UserProfileQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type UserProfileQuery = { __typename?: 'Query', user?: { __typename?: 'UserType', discord: string, phone: string, _id: string, name: string, batch?: number | null, email: string, profilePicture?: string | null, bio?: string | null, posted?: Array<{ __typename?: 'NoticeType', _id: string, time: string, title: string, body: string, topics?: Array<{ __typename?: 'TopicType', name: string, color: string }> | null }> | null, preferences: { __typename: 'PreferencesType', darkmode?: boolean | null, notifications?: boolean | null, roundup?: boolean | null }, subscriptions?: Array<{ __typename?: 'TopicType', _id: string, name: string, color: string }> | null, subscribedEvents?: Array<{ __typename?: 'EventType', _id: string, name: string, date: string, venue: string, meetLink: string }> | null } | null };
+export type UserProfileQuery = { __typename?: 'Query', user?: { __typename?: 'UserType', discord: string, phone: string, _id: string, name: string, batch: number, email: string, profilePicture: string, bio: string, posted?: Array<{ __typename?: 'NoticeType', _id: string, time: string, title: string, body: string, topics?: Array<{ __typename?: 'TopicType', name: string, color: string }> | null }> | null, preferences: { __typename: 'PreferencesType', darkmode?: boolean | null, notifications?: boolean | null, roundup?: boolean | null }, subscriptions?: Array<{ __typename?: 'TopicType', _id: string, name: string, color: string }> | null, subscribedEvents?: Array<{ __typename?: 'EventType', _id: string, name: string, date: string, venue: string, meetLink: string }> | null } | null };
 
 export const MinPostFragmentDoc = gql`
     fragment MinPost on NoticeType {
@@ -672,6 +687,67 @@ export function useCreateFileUploadUrlLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type CreateFileUploadUrlQueryHookResult = ReturnType<typeof useCreateFileUploadUrlQuery>;
 export type CreateFileUploadUrlLazyQueryHookResult = ReturnType<typeof useCreateFileUploadUrlLazyQuery>;
 export type CreateFileUploadUrlQueryResult = Apollo.QueryResult<CreateFileUploadUrlQuery, CreateFileUploadUrlQueryVariables>;
+export const GetFeedDocument = gql`
+    query GetFeed($limit: Float, $skip: Float) {
+  getFeed(limit: $limit, skip: $skip) {
+    data {
+      _id
+      title
+      body
+      time
+      postedBy {
+        _id
+        name
+        profilePicture
+      }
+      attachedImages
+      topics {
+        _id
+        name
+        color
+      }
+      isEvent
+      linkedEvents {
+        _id
+        name
+        venue
+        date
+        meetLink
+      }
+      likeCount
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetFeedQuery__
+ *
+ * To run a query within a React component, call `useGetFeedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetFeedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetFeedQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *      skip: // value for 'skip'
+ *   },
+ * });
+ */
+export function useGetFeedQuery(baseOptions?: Apollo.QueryHookOptions<GetFeedQuery, GetFeedQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetFeedQuery, GetFeedQueryVariables>(GetFeedDocument, options);
+      }
+export function useGetFeedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetFeedQuery, GetFeedQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetFeedQuery, GetFeedQueryVariables>(GetFeedDocument, options);
+        }
+export type GetFeedQueryHookResult = ReturnType<typeof useGetFeedQuery>;
+export type GetFeedLazyQueryHookResult = ReturnType<typeof useGetFeedLazyQuery>;
+export type GetFeedQueryResult = Apollo.QueryResult<GetFeedQuery, GetFeedQueryVariables>;
 export const GoogleAuthUrlDocument = gql`
     query GoogleAuthURL {
   url: GoogleAuthUrl

--- a/graphql/generated/schema.graphql
+++ b/graphql/generated/schema.graphql
@@ -150,6 +150,7 @@ type Query {
   getAllTests(limit: Int = 0, skip: Int = 0): PaginatedResponseOfTestType!
   getAllTopics(limit: Int = 0, skip: Int = 0): PaginatedResponseOfTopicType!
   getAllUsers(limit: Int = 0, skip: Int = 0): PaginatedResponseOfUserType!
+  getFeed(limit: Float = 5, skip: Float = 0): PaginatedResponseOfNoticeType!
   getFileURL(filenames: [String!]!): [String!]!
   getNotSubscribedTopics: [TopicType!]!
   getNoticesByTopic(topicId: String!): [NoticeType]!
@@ -215,15 +216,15 @@ input UserRegisterType {
 type UserType {
   _id: ID!
   banned: Boolean
-  batch: Int
-  bio: String
+  batch: Int!
+  bio: String!
   discord: String!
   email: String!
   name: String!
   phone: String!
   posted: [NoticeType!]
   preferences: PreferencesType!
-  profilePicture: String
+  profilePicture: String!
   role: String!
   subscribedEvents: [EventType!]
   subscriptions: [TopicType!]

--- a/graphql/src/queries/GetFeedQuery.gql
+++ b/graphql/src/queries/GetFeedQuery.gql
@@ -1,0 +1,30 @@
+query GetFeed($limit: Float, $skip: Float) {
+    getFeed(limit: $limit, skip: $skip) {
+        data {
+            _id
+            title
+            body
+            time
+            postedBy {
+                _id
+                name
+                profilePicture
+            }
+            attachedImages
+            topics {
+                _id
+                name
+                color
+            }
+            isEvent
+            linkedEvents {
+                _id
+                name
+                venue
+                date
+                meetLink
+            }
+            likeCount
+        }
+    }
+}

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -1,5 +1,6 @@
 import FeedPost from '@/feed/components/FeedPost';
 import FeedLayout from '@/feed/layouts';
+import { useGetFeedLazyQuery } from '@/graphql/generated';
 import withApollo from '@/lib/withApollo';
 import Button from '@/shared/ui/Button';
 import FormDropdown from '@/shared/ui/Form/FormDropdown';
@@ -8,7 +9,78 @@ import type { NextPage } from 'next';
 import Link from 'next/link';
 import React from 'react';
 
+const colors = {
+	red: 'bg-red-500 text-gray-800',
+	green: 'bg-green-500',
+	purple: 'bg-purple-500',
+	teal: 'bg-teal-500 text-gray-800',
+	blue: 'bg-blue-500',
+};
+
+const mockNotice = {
+	_id: "abc123",
+	title: "Lorem Ipsum",
+	body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec tempor arcu. Nulla facilisi. Phasellus sapien risus, auctor feugiat lorem vitae, vulputate euismod nulla. Proin laoreet odio condimentum turpis bibendum, vitae luctus sapien pulvinar. Mauris vitae suscipit odio. Etiam rhoncus luctus quam eget condimentum. Fusce quis elit sed turpis porttitor euismod.",
+	time: "2022-10-04T13:10:52.525Z",
+	postedBy: {
+		_id: "633417dd9401de010eebdee7",
+		name: "ANIMESH AV",
+		profilePicture: "https://d23hwxa527zkay.cloudfront.net/f20200193.jpg"
+	},
+	attachedImages: [
+		'https://picsum.photos/200/300',
+		'https://picsum.photos/200/301',
+		'https://picsum.photos/200/302',
+	],
+	topics: [
+		{
+			_id: '614c8f08fe60d017770f5ec7',
+			name: 'Linkbuzz',
+			color: "blue" as keyof typeof colors
+		},
+		{
+			_id: '614c8f08fe60d017770f5ec8',
+			name: 'Eabox',
+			color: "purple"
+		},
+	],
+	isEvent: false,
+	linkedEvents: [
+		{
+			"_id": "633c3156cd75e701a37dc75b",
+			"name": "First Event in History",
+			"venue": "LTC Lobby",
+			"description": "Some random event which no one attends",
+			"date": "16/10/2022 4:00PM"
+		},
+		{
+			"_id": "633c3156cd75e701a37dc75c",
+			"name": "Second Event in History",
+			"venue": "Mess 1",
+			"description": "Some other random event which no one attends",
+			"date": "16/10/2022 4:00PM",
+			"meetLink": "https://meet.google.com"
+		}
+	],
+	likeCount: 12
+}
+
 const FeedIndexRoute: NextPage = () => {
+	const [getFeed, {loading, data}] = useGetFeedLazyQuery();
+	
+	React.useEffect(() => {
+		getFeed({
+			variables: {
+				limit: 5,
+				skip: 0,
+			}
+		});
+	},[]);
+
+	React.useEffect(() => {
+		console.log(data);
+	},[loading]);
+
 	return (
 		<>
 			<FeedLayout>
@@ -51,8 +123,12 @@ const FeedIndexRoute: NextPage = () => {
 						</div>
 					</div>
 					<div className="mt-8 flex flex-col gap-8 py-3 sm:px-8 lg:px-10">
-						<FeedPost />
-						<FeedPost />
+						{data?
+						data.getFeed.data.map(notice => <FeedPost key={notice._id} notice={notice} />): <></>}
+						{/* @ts-ignore */}
+						<FeedPost notice={mockNotice} />
+						{/* @ts-ignore */}
+						<FeedPost notice={mockNotice} />
 					</div>
 				</div>
 			</FeedLayout>

--- a/pages/feed/new.tsx
+++ b/pages/feed/new.tsx
@@ -3,12 +3,13 @@ import BoundingBox from '@/feed/new/components/BoundingBox';
 import EventInput from '@/feed/new/components/EventInput';
 import useLinkedEvents from '@/feed/new/hooks/useLinkedEvents';
 import AppLayout from '@/global/layouts/AppLayout';
-import { TopicType, useCreateNoticeMutation } from '@/graphql/generated';
+import { TopicType, useCreateNoticeMutation, useLoggedInUserQuery } from '@/graphql/generated';
 import withApollo from '@/lib/withApollo';
 import EventItem from '@/shared/components/EventItem';
 import TopicsModal from '@/shared/components/TopicsModal';
 import useDisclosure from '@/shared/hooks/useDisclosure';
 import Button from '@/shared/ui/Button';
+import Spinner from '@/shared/ui/Spinner';
 import Tag from '@/shared/ui/Tag';
 import TextArea from '@/shared/ui/TextArea';
 import React from 'react';
@@ -146,6 +147,8 @@ interface NoticeDetails {
 }
 
 const EditPostLayout: React.FC<any> = ({ children }) => {
+	const {loading: userLoading, data:userData} = useLoggedInUserQuery();
+
 	const { isOpen, onClose, onOpen } = useDisclosure();
 	const [selectedTags, setSelectedTags] = React.useState<any[]>([
 		{
@@ -230,6 +233,7 @@ const EditPostLayout: React.FC<any> = ({ children }) => {
 	}
 
 	return (
+		userLoading? <Spinner></Spinner> :
 		<>
 			{/* @ts-ignore */}
 			<TopicsModal
@@ -263,7 +267,7 @@ const EditPostLayout: React.FC<any> = ({ children }) => {
 														key={tag._id}
 														color={'purple'}
 														onClick={() => {
-															const a = 1+2
+															const a = 1+2;
 														}}
 													>
 														{tag.name}
@@ -319,7 +323,21 @@ const EditPostLayout: React.FC<any> = ({ children }) => {
 						{/* Preview Notice */}
 						<BoundingBox>
 							<h4 className="mt-1 font-semibold">Notice Preview</h4>
-							<FeedPost showActions={false}></FeedPost>
+							<FeedPost notice={{
+								title: noticeDetails.title,
+								body: noticeDetails.body,
+								linkedEvents: linkedEvents,
+								isEvent: true,
+								attachedImages: noticeDetails.attachedImages,
+								likeCount: 0,
+								postedBy: {
+									_id: userData!.user!._id,
+									name: userData!.user!.name,
+									profilePicture: userData!.user!.profilePicture
+								},
+								time: new Date().toISOString(),
+								topics: selectedTags,
+							}} showActions={false}></FeedPost>
 						</BoundingBox>
 
 						{/* Preview Events */}
@@ -333,7 +351,10 @@ const EditPostLayout: React.FC<any> = ({ children }) => {
 									key={index}
 									event={{
 										name: linkedEvents[index].title,
-										meetLink: linkedEvents[index].venue,
+										meetLink: linkedEvents[index].meetLink,
+										date: linkedEvents[index].date,
+										venue: linkedEvents[index].venue,
+										description: linkedEvents[index].description
 									}}
 								/>
 							);

--- a/src/feed/components/FeedPost/FeedPost.tsx
+++ b/src/feed/components/FeedPost/FeedPost.tsx
@@ -13,13 +13,19 @@ import {
 } from 'react-icons/hi';
 import clsx from 'clsx';
 import Image from 'next/image';
+import EventItem from '@/shared/components/EventItem';
 
 interface PostGalleryProps {
 	images: string[];
 }
 
 const PostGallery: React.FC<PostGalleryProps> = ({ images }) => {
-	if (images.length == 1) {
+	if(images.length == 0) {
+		return (
+			<></>
+		)
+	}
+	else if (images.length == 1) {
 		return (
 			<div data-testid="post-gallery" className={'relative'}>
 				<img src={images[0]} className="w-full" />
@@ -91,16 +97,34 @@ const PostReminder: React.FC = () => {
 	);
 };
 
-interface FeedPostProps {
-	showActions?: boolean;
+interface NoticeDetails {
+	_id?: string;
+	postedBy: {
+		_id: string,
+		name: string,
+		profilePicture: string
+	};
+	title: string;
+	body: string;
+	time: string;
+	attachedImages?: string[] | null | undefined;
+	topics?: {
+		_id: string,
+		name: string,
+		color: string
+	}[] | null | undefined;
+	isEvent: boolean;
+	linkedEvents: any[];
+	likeCount: number;
 }
 
-const FeedPost: React.FC<FeedPostProps> = ({ showActions = true }) => {
-	const images = [
-		'https://picsum.photos/200/300',
-		'https://picsum.photos/200/300',
-		'https://picsum.photos/200/300',
-	];
+interface FeedPostProps {
+	showActions?: boolean;
+	notice: NoticeDetails
+}
+
+const FeedPost: React.FC<FeedPostProps> = ({ showActions = true, notice }) => {
+	const {_id, postedBy, body, time, attachedImages, topics, linkedEvents, likeCount} = notice;
 
 	return (
 		<div className="relative bg-gray-800 sm:rounded-lg">
@@ -109,59 +133,52 @@ const FeedPost: React.FC<FeedPostProps> = ({ showActions = true }) => {
 				<div className="px-4 pb-2 pt-4 lg:pt-1">
 					<div className="flex items-center justify-between pt-4 lg:items-end">
 						<div className="flex gap-2">
-							<Avatar size="x-small" />
+							<Avatar src={postedBy.profilePicture} size="x-small" />
 							<div>
-								<h4 className="text-sm font-semibold">John Smith</h4>
-								<p className="text-xs font-light">10 mins ago</p>
+								<h4 className="text-sm font-semibold">{postedBy.name}</h4>
+								<p className="text-xs font-light">{time}</p>
 							</div>
 						</div>
 
 						<div className="text-right">
 							<div className="hidden gap-2 lg:flex">
-								<Tag color="red">cRuX</Tag>
-								<Tag color="blue">IEEE</Tag>
-								<Tag color="purple">Automation and Robotics</Tag>
+								{/* @ts-ignore */}
+								{topics?.map(topic => <Tag key={topic._id} color={topic.color}>{topic.name}</Tag>)}
 							</div>
 						</div>
 					</div>
 					<div className="mt-3 flex gap-2 lg:hidden">
-						<Tag color="red">cRuX</Tag>
-						<Tag color="blue">IEEE</Tag>
-						<Tag color="purple">Automation and Robotics</Tag>
+						{/* @ts-ignore */}
+						{topics?.map(topic => <Tag key={topic._id} color={topic.color}>{topic.name}</Tag>)}
 					</div>
 
 					{/* text */}
 					<div className="my-4">
 						<p className="text-sm font-light">
-							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec
-							tempor arcu. Nulla facilisi. Phasellus sapien risus, auctor
-							feugiat lorem vitae, vulputate euismod nulla. Proin laoreet odio
-							condimentum turpis bibendum, vitae luctus sapien pulvinar. Mauris
-							vitae suscipit odio. Etiam rhoncus luctus quam eget condimentum.
-							Fusce quis elit sed turpis porttitor euismod.
+							{body}
 						</p>
 					</div>
 				</div>
 
 				{/* pictures */}
 				<div className="p-0 sm:px-4">
-					<PostGallery images={images} />
+					<PostGallery images={attachedImages ?? []} />
 				</div>
 
 				{/* post actions */}
 				{showActions && (
 					<div className="mt-2 px-4 pb-2 pt-4 lg:pt-1">
-						{/* reactions count */}
-						<div className="flex items-center justify-between py-1 px-2">
-							<p className="text-sm font-light">12 likes</p>
-							<p className="text-sm font-light">15 comments</p>
+						{/* Linked Events */}
+						<div>
+							<h4 className="font-semibold">Events</h4>
+							{linkedEvents.map(event => <EventItem key={event._id} event={event} shadow={true} />)}
 						</div>
 
-						{/* reminder */}
-
-						<PostReminder />
-
-						{/* <hr className='border border-gray-disabled mb-2 mt-0.5' /> */}
+						{/* reactions count */}
+						<div className="flex items-center justify-between py-1 px-2">
+							<p className="text-sm font-light">{likeCount} likes</p>
+							{/* <p className="text-sm font-light">15 comments</p> */}
+						</div>
 
 						{/* reaction buttons */}
 						<div className="grid grid-cols-3">

--- a/src/feed/components/LeftSidebar/LeftSidebar.tsx
+++ b/src/feed/components/LeftSidebar/LeftSidebar.tsx
@@ -6,8 +6,11 @@ import React from 'react';
 const LeftSideBar: React.FC = () => {
 	const testEvent = {
 		meetLink: 'https://katelin.name',
-		name: 'cross-platform',
+		name: 'ACC Fair',
 		__typename: 'EventType',
+		date: "16/10/2022 4:00 PM",
+		description: "Clubs Introduction Event For the 2022 batch",
+		venue: "LTC Lobby"
 	};
 
 	return (

--- a/src/feed/new/hooks/useLinkedEvents/useLinkedEvents.tsx
+++ b/src/feed/new/hooks/useLinkedEvents/useLinkedEvents.tsx
@@ -4,7 +4,8 @@ interface LinkedEvent {
 	title: string,
 	date: string,
 	venue: string,
-	description: string
+	description: string,
+    meetLink: string
 }
 
 const useLinkedEvents = () => {
@@ -15,7 +16,8 @@ const useLinkedEvents = () => {
             title: "",
             date: "",
             venue: "",
-            description: ""
+            description: "",
+            meetLink: "",
         }
         setLinkedEvents([...linkedEvents, newEvent]);
     }

--- a/src/shared/components/EventItem/EventItem.tsx
+++ b/src/shared/components/EventItem/EventItem.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import IconButton from '../../ui/IconButton';
 import Avatar from '../../ui/Avatar';
-import { HiOutlineBell } from 'react-icons/hi';
+import { HiOutlineBell, HiOutlineLink, HiOutlineMap } from 'react-icons/hi';
+import {BiMap} from 'react-icons/bi'
 import Link from '@/shared/ui/Link';
 
 interface EventItemProps {
 	bottomBorder?: boolean;
+	shadow?: boolean;
 	event: {
 		name: string;
 		meetLink: string;
+		date: string;
+		venue: string;
+		description: string;
 	};
 }
 
 const EventItem: React.FC<EventItemProps> = ({
 	bottomBorder = true,
-	event: { name, meetLink },
+	shadow = false,
+	event: { name, meetLink, date, venue, description},
 }) => {
 	return (
 		<>
@@ -22,17 +28,29 @@ const EventItem: React.FC<EventItemProps> = ({
 				data-testid="event-item"
 				className={`flex gap-3 ${
 					bottomBorder ? 'mb-5' : ''
-				} items-center rounded bg-gray-800 p-3`}
+				} ${shadow? 'shadow-2xl' : ''} items-center rounded bg-gray-800 p-3`}
 			>
 				<Avatar size="x-small" />
 				<div className="grid flex-1 items-center gap-y-3">
 					<div className="row-start-1 row-end-3 items-center">
 						<h4 className="font-semibold lg:text-sm">{name}</h4>
-						<Link href="#">{meetLink}</Link>
+						<p className="mb-3">{description}</p>
+						{/* Venue and Meet Link */}
+						<div className="grid grid-cols-2">
+							<div className="flex flex-start">
+								<BiMap className="text-teal-500 h-5 w-5 mr-2"/>
+								<p>{venue}</p>
+							</div>
+							{meetLink &&
+							<div className="flex flex-start">
+								<HiOutlineLink className="text-teal-500 h-5 w-5 mr-2"/>
+								<Link href={meetLink}>Meet Link</Link>
+							</div>}
+						</div>
 					</div>
 
 					<div className="col-start-2 col-end-2 text-right">
-						<p className="self-end text-xs opacity-60 ">06/09/2021 4:20 PM</p>
+						<p className="self-end text-xs opacity-60 ">{date}</p>
 					</div>
 
 					<div className="col-start-2 col-end-2 flex justify-end">


### PR DESCRIPTION
# Add GetFeed Query

Added a get feed query which has the support for pagination and returns a list of notices based on the `skip` and `limit` parameters.

# Integrate Feed Screen

Refactored the FeedPost Component to include all the necessary fields like events, comments, likes etc.

# Notice Preview in /feed/new

The notice preview now works dynamically when typing the notice in the /feed/new screen